### PR TITLE
Add greater jQuery compatibility

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,6 +24,6 @@
     "tests"
   ],
   "dependencies": {
-    "jquery": "~2.2.0"
+    "jquery": ">=1.9"
   }
 }


### PR DESCRIPTION
Allows for greater compatibility with other jQuery versions. Since the last major changes in the 1.x branch was in 1.9 and since this code doesn't do anything crazy I figured that was a sensible version to limit at.
